### PR TITLE
GUNDI-3756: Fix pull_events `annotations` validator

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -45,6 +45,8 @@ class PullEventsConfig(PullActionConfiguration):
 
     @pydantic.validator("annotations", always=True)
     def validate_json(cls, v):
+        if not v:
+            return None
         v = v.strip()
         if(v == ""):
             return None


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-3756

This pull request includes a small change to the `validate_json` method in the `app/actions/configurations.py` file. 

The change ensures that if the `annotations` field is empty (null) from the portal, it returns `None`. 

* [`app/actions/configurations.py`](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895R48-R49): Added a condition to return `None` if the `annotations` field is empty in the `validate_json` method.