### PR TITLE
Await when patching events in Gundi

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -236,7 +236,7 @@ async def patch_events(events, updated_config_data, integration):
         new_event = event[1]
         transformed_data = _transform_inat_to_gundi_event(new_event, updated_config_data)
         if transformed_data:
-            response = update_event_in_gundi(
+            response = await update_event_in_gundi(
                 event_id=gundi_object_id,
                 event=transformed_data,
                 integration_id=str(integration.id)


### PR DESCRIPTION
This pull request includes an important change to the `app/actions/handlers.py` file. 

The change involves updating the `patch_events` function to use asynchronous behavior when calling the `update_event_in_gundi` function.

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L239-R239): Modified the `patch_events` function to use `await` for the `update_event_in_gundi` call, ensuring it handles asynchronous operations properly.