### PR TITLE
GUNDI-3986: Log activity on attachments posting error and continue

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -248,12 +248,15 @@ async def process_attachments(events, response, all_event_photos, integration):
                 "integration_id": str(integration.id),
                 "attention_needed": True
             })
+            log_data = {"message": message}
+            if server_response := getattr(e, "response", None):
+                log_data["server_response_body"] = server_response.text
             await log_activity(
                 integration_id=integration.id,
                 action_id="pull_events",
                 level=LogLevel.WARNING,
                 title=message,
-                data={"message": message}
+                data=log_data
             )
             continue
     return attachments_processed

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -238,12 +238,24 @@ async def process_attachments(events, response, all_event_photos, integration):
             if response:
                 attachments_processed += len(attachments)
         except Exception as e:
-            message = f"Error while processing event attachments for event ID '{event_id['object_id']}'. Exception: {e}."
+            request = {
+                "event_id": gundi_id,
+                "attachments": attachments,
+                "integration_id": str(integration.id)
+            }
+            message = f"Error while processing event attachments for event ID '{event_id['object_id']}'. Exception: {e}. Request: {request}"
             logger.exception(message, extra={
                 "integration_id": str(integration.id),
                 "attention_needed": True
             })
-            raise e
+            await log_activity(
+                integration_id=integration.id,
+                action_id="pull_events",
+                level=LogLevel.WARNING,
+                title=message,
+                data={"message": message}
+            )
+            continue
     return attachments_processed
 
 


### PR DESCRIPTION
This pull request includes a significant update to the error handling and logging mechanism in the `process_attachments` function within the `app/actions/handlers.py` file. 

The most important changes include adding detailed request information to the error message, logging the activity asynchronously, and continuing the process instead of raising an exception.

Error handling improvements:

* Enhanced the error message to include detailed request information such as `event_id`, `attachments`, and `integration_id`.
* Updated the logging mechanism to log the activity asynchronously using the `log_activity` function, including the integration ID, action ID, log level, title, and data.
* Changed the error handling flow to continue processing after logging the error instead of raising an exception, ensuring that the process is more resilient.


### Context

![image](https://github.com/user-attachments/assets/c7033343-f8ef-4536-b11f-174dca175207)

A iNat connection is returning 400 status from the sensors API. Usually, this happens because the attachments related event was discarded as duplicate or simply is not created yet, so the sensors API returns 400.

With this approach, we create an activity log to report the issue and continue with the other attachments, without raising the exception, to allow all the other events to be processed.
