### PR TITLE
GUNDI-3986: Early return if no photos available

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -220,9 +220,12 @@ async def process_attachments(events, response, all_event_photos, integration):
     for event, event_id in zip(events, response):
         inat_id = event['event_details']['inat_id']
         gundi_id = event_id['object_id']
+        available_photos = all_event_photos.get(inat_id, [])
+        if not available_photos:
+            continue
         attachments = []
         try:
-            for photo_id, photo_url in all_event_photos.get(inat_id, []):
+            for photo_id, photo_url in available_photos:
                 logger.info(f"Adding {photo_url} from iNat event {inat_id} to Gundi event {gundi_id}")
                 fp = urlretrieve(photo_url)
                 path = urlparse(photo_url).path


### PR DESCRIPTION
This pull request includes a small change to the `process_attachments` function in the `app/actions/handlers.py` file. +

The change ensures that the function skips events that have no available photos, improving the efficiency of the attachment processing.

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R223-R228): Added a check to skip events with no available photos in the `process_attachments` function.