### PR TITLE
GUNDI-4112: Sub-actions support for attachments processing

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,7 +1,7 @@
 from typing import Optional, List, Dict
 import json
 import pydantic
-from .core import PullActionConfiguration, AuthActionConfiguration, ExecutableActionMixin
+from .core import PullActionConfiguration, AuthActionConfiguration, ExecutableActionMixin, InternalActionConfiguration
 from app.services.utils import FieldWithUIOptions, GlobalUISchemaOptions, UIOptions
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
@@ -123,3 +123,8 @@ class PullEventsConfig(PullActionConfiguration):
             ],
             "required": ["bounding_box", "days_to_load"]
         }
+
+class ProcessAttachmentsPerChunkConfig(InternalActionConfiguration):
+    observations_chunk: List[dict]
+    observations_response: List[dict]
+    event_photos: dict

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -81,3 +81,5 @@ async def test_execute_pull_observations_action_without_bounding_box(
     assert response["result"].get("triggered_process_attachments_actions") == 1
     assert mock_get_observations_v2.called
     assert mock_get_observations_v2.call_count == 2
+
+    mock_trigger_action.assert_called_once()

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -17,8 +17,12 @@ async def test_execute_pull_observations_action(
     mock_config_manager.get_integration_details.return_value = async_return(inaturalist_integration_v2)
     mock_config_manager.get_action_configuration.return_value = async_return(inaturalist_integration_v2.configurations[0])
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", return_value=None)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_trigger_action = mocker.patch("app.actions.handlers.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mock_state_manager.get_state.return_value = async_return({})
     mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
@@ -38,6 +42,8 @@ async def test_execute_pull_observations_action(
     assert mock_get_observations_v2.called
     assert mock_get_observations_v2.call_count == 2
 
+    mock_trigger_action.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_execute_pull_observations_action_without_bounding_box(
@@ -51,8 +57,12 @@ async def test_execute_pull_observations_action_without_bounding_box(
     mock_config_manager.get_integration_details.return_value = async_return(inaturalist_integration_v2_without_bounding_box)
     mock_config_manager.get_action_configuration.return_value = async_return(inaturalist_integration_v2_without_bounding_box.configurations[0])
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", return_value=None)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_trigger_action = mocker.patch("app.actions.handlers.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mock_state_manager.get_state.return_value = async_return({})
     mocker.patch("app.actions.handlers.state_manager", mock_state_manager)

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -1,4 +1,6 @@
 import pytest
+
+from app import settings
 from app.conftest import async_return
 from app.services.action_runner import execute_action
 
@@ -9,6 +11,9 @@ async def test_execute_pull_observations_action(
         mock_get_gundi_api_key, mock_gundi_sensors_client_class, mock_config_manager,
         mock_get_observations_v2, mock_publish_event, mock_gundi_client_v2_class
 ):
+    settings.TRIGGER_ACTIONS_ALWAYS_SYNC = False
+    settings.INTEGRATION_COMMANDS_TOPIC = "inaturalist-actions-topic"
+
     mock_config_manager.get_integration_details.return_value = async_return(inaturalist_integration_v2)
     mock_config_manager.get_action_configuration.return_value = async_return(inaturalist_integration_v2.configurations[0])
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
@@ -40,6 +45,9 @@ async def test_execute_pull_observations_action_without_bounding_box(
         mock_get_gundi_api_key, mock_gundi_sensors_client_class, mock_config_manager,
         mock_get_observations_v2, mock_publish_event, mock_gundi_client_v2_class
 ):
+    settings.TRIGGER_ACTIONS_ALWAYS_SYNC = False
+    settings.INTEGRATION_COMMANDS_TOPIC = "inaturalist-actions-topic"
+
     mock_config_manager.get_integration_details.return_value = async_return(inaturalist_integration_v2_without_bounding_box)
     mock_config_manager.get_action_configuration.return_value = async_return(inaturalist_integration_v2_without_bounding_box.configurations[0])
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -29,7 +29,7 @@ async def test_execute_pull_observations_action(
     assert "result" in response
     assert response["result"].get("events_extracted") == 2
     assert response["result"].get("events_updated") == 0
-    assert response["result"].get("photos_attached") == 5
+    assert response["result"].get("triggered_process_attachments_actions") == 1
     assert mock_get_observations_v2.called
     assert mock_get_observations_v2.call_count == 2
 
@@ -60,6 +60,6 @@ async def test_execute_pull_observations_action_without_bounding_box(
     assert "result" in response
     assert response["result"].get("events_extracted") == 2
     assert response["result"].get("events_updated") == 0
-    assert response["result"].get("photos_attached") == 5
+    assert response["result"].get("triggered_process_attachments_actions") == 1
     assert mock_get_observations_v2.called
     assert mock_get_observations_v2.call_count == 2


### PR DESCRIPTION
This pull request introduces a new internal action configuration and refactors the handling of attachments in the `get_inaturalist_events_to_patch` function. 

The main changes include adding a new configuration class, updating imports, and modifying the logic to trigger the new action for processing attachments.

New internal action configuration:

* [`app/actions/configurations.py`](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895R126-R130): Added `ProcessAttachmentsPerChunkConfig` class to handle chunks of observations and their responses.

Refactoring attachment handling:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L6-L16): Updated imports to include `ProcessAttachmentsPerChunkConfig` and `trigger_action`.
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L162-R160): Replaced the `process_attachments` call with the new `trigger_action` for `process_attachments_per_chunk` and updated the return values to reflect the new action. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L162-R160) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L192-R197) [[3]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L215-R228)
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L215-R228): Refactored the `process_attachments` function to `action_process_attachments_per_chunk` to use the new configuration class. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L215-R228) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L270-R275)