### PR TITLE
Release 20250307 hotfix

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -21,6 +21,8 @@ GUNDI_SUBMISSION_CHUNK_SIZE = 100
 # Pull-events state: single key for the cursor (legacy "updated_to" still read for backward compatibility)
 STATE_LAST_RUN_KEY = "last_run"
 STATE_DATETIME_FMT = "%Y-%m-%d %H:%M:%S%z"
+# Per-observation state: when we last synced this observation to Gundi (so we only patch when it changes)
+STATE_INAT_UPDATED_AT_KEY = "inat_updated_at"
 
 logger = logging.getLogger(__name__)
 state_manager = IntegrationStateManager()
@@ -102,16 +104,30 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     logger.info(f"Processing {len(observations)} observations from iNaturalist.")
 
     async def get_inaturalist_events_to_patch():
-        # Get through the events and check if state_manager has it recorded from a previous execution
+        # Split observations into: new (create in Gundi) vs existing (patch only if observation changed).
         patch_these_events = []
         process_these_events = []
         for event_id, observation in observations.items():
             saved_event = await state_manager.get_state(str(integration.id), "pull_events", str(event_id))
-            if saved_event:
-                # Event already exists, will patch it
-                patch_these_events.append((saved_event.get("object_id"), observation))
-            else:
+            if not saved_event:
                 process_these_events.append(observation)
+                continue
+            # Only patch when the observation has changed since we last synced it (avoids updating every run)
+            last_synced_at = saved_event.get(STATE_INAT_UPDATED_AT_KEY)
+            if last_synced_at:
+                try:
+                    if isinstance(last_synced_at, str):
+                        last_synced_at = datetime.strptime(last_synced_at, STATE_DATETIME_FMT)
+                    ob_updated = observation.updated_at
+                    if ob_updated.tzinfo is None:
+                        ob_updated = ob_updated.replace(tzinfo=timezone.utc)
+                    if last_synced_at.tzinfo is None:
+                        last_synced_at = last_synced_at.replace(tzinfo=timezone.utc)
+                    if ob_updated <= last_synced_at:
+                        continue  # Already in sync, skip patch
+                except (ValueError, TypeError):
+                    pass  # Bad or legacy value, patch to be safe
+            patch_these_events.append((saved_event.get("object_id"), observation))
         return process_these_events, patch_these_events
 
     filtered_observations, events_to_patch = await get_inaturalist_events_to_patch()
@@ -124,6 +140,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
 
     if filtered_observations:
         all_event_photos = {}
+        inat_updated_at_map = {}  # inat_id -> updated_at for state we persist after create
         newest = None
         for ob in filtered_observations:
 
@@ -134,6 +151,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
             events_to_process.append(e)
 
             inat_id = e['event_details']['inat_id']
+            inat_updated_at_map[inat_id] = ob.updated_at
             all_event_photos[inat_id] = []
             for photo in ob.photos:
                 all_event_photos[inat_id].append((photo.id, photo.large_url if photo.large_url else photo.url))
@@ -153,7 +171,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
                     attachments_response = await process_attachments(to_add_chunk, response, all_event_photos, integration)
                     attachment_count += attachments_response
                 # Process events to patch
-                await save_events_state(response, to_add_chunk, integration)
+                await save_events_state(response, to_add_chunk, integration, inat_updated_at_map)
 
     else:
         logger.info(f"No new iNaturalist observations to process for integration ID: {str(integration.id)}.")
@@ -163,6 +181,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         logger.info(f"Updating {len(events_to_patch)} events from iNaturalist observations to Gundi for integration ID: {str(integration.id)}.")
         response = await patch_events(events_to_patch, action_config, integration)
         updated_count += len(response)
+        await save_patched_events_state(events_to_patch, integration)
 
     last_updated = max(ob.updated_at for ob in observations.values())
     logger.info("Updating state through %s", last_updated)
@@ -246,14 +265,23 @@ async def patch_events(events, updated_config_data, integration):
     return responses
 
 
-async def save_events_state(response, events, integration):
+async def save_events_state(response, events, integration, inat_updated_at_map=None):
+    """Persist Gundi event state per observation so we know what we created and when we last synced."""
+    inat_updated_at_map = inat_updated_at_map or {}
     for saved_event, event in zip(response, events):
         try:
             event_id = event["event_details"]["inat_id"]
+            state = dict(saved_event)
+            updated_at = inat_updated_at_map.get(event_id)
+            if updated_at is not None:
+                state[STATE_INAT_UPDATED_AT_KEY] = (
+                    updated_at.strftime(STATE_DATETIME_FMT)
+                    if hasattr(updated_at, "strftime") else str(updated_at)
+                )
             await state_manager.set_state(
                 integration_id=str(integration.id),
                 action_id="pull_events",
-                state=saved_event,
+                state=state,
                 source_id=event_id
             )
         except Exception as e:
@@ -263,6 +291,34 @@ async def save_events_state(response, events, integration):
                 "integration_id": str(integration.id),
                 "attention_needed": True
             })
+            raise e
+
+
+async def save_patched_events_state(events_to_patch, integration):
+    """After patching, update per-observation state so we don't patch again until the observation changes."""
+    for gundi_object_id, observation in events_to_patch:
+        try:
+            updated_at = observation.updated_at
+            state = {
+                "object_id": gundi_object_id,
+                STATE_INAT_UPDATED_AT_KEY: (
+                    updated_at.strftime(STATE_DATETIME_FMT)
+                    if hasattr(updated_at, "strftime") else str(updated_at)
+                ),
+            }
+            await state_manager.set_state(
+                integration_id=str(integration.id),
+                action_id="pull_events",
+                state=state,
+                source_id=str(observation.id),
+            )
+        except Exception as e:
+            logger.exception(
+                "Error saving state for patched observation %s: %s",
+                observation.id,
+                e,
+                extra={"integration_id": str(integration.id), "attention_needed": True},
+            )
             raise e
 
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,19 +1,20 @@
-import httpx
+from datetime import date, datetime, timedelta, timezone
 import logging
-
-from datetime import datetime, timezone, timedelta
 from math import ceil
-from app.actions.configurations import AuthenticateConfig, PullEventsConfig
-from app.services.activity_logger import activity_logger, log_action_activity
-from app.services.gundi import send_events_to_gundi, update_event_in_gundi, send_event_attachments_to_gundi
-from app.services.state import IntegrationStateManager
-from gundi_core.schemas.v2 import Integration, LogLevel
-from pyinaturalist import get_observations_v2, Observation, Annotation
 from typing import Dict, List
-from urllib.parse import urlparse
-from urllib.request import urlretrieve
 
-import re
+from gundi_core.schemas.v2 import Integration, LogLevel
+import httpx
+from pyinaturalist import Annotation, Observation, get_observations_v2
+
+from app.actions.configurations import PullEventsConfig
+from app.services.activity_logger import activity_logger, log_action_activity
+from app.services.gundi import (
+    send_event_attachments_to_gundi,
+    send_events_to_gundi,
+    update_event_in_gundi,
+)
+from app.services.state import IntegrationStateManager
 
 GUNDI_SUBMISSION_CHUNK_SIZE = 100
 
@@ -69,8 +70,8 @@ def get_inaturalist_observations(integration: Integration, config: PullEventsCon
         get_observations_params["swlat"] = swlat
         get_observations_params["swlng"] = swlng
     inat_count_req = get_observations_v2(**get_observations_params)
-    inat_count = inat_count_req.get("total_results")
-    pages = ceil(inat_count/200)
+    inat_count = inat_count_req.get("total_results") or 0
+    pages = ceil(inat_count / 200) if inat_count else 0
 
     observation_map = {}
     for page in range(1,pages+1):
@@ -238,12 +239,12 @@ async def process_attachments(events, response, all_event_photos, integration):
 
                 attachments.append((filename, img))
 
-            response = await send_event_attachments_to_gundi(
+            attachments_response = await send_event_attachments_to_gundi(
                 event_id=gundi_id,
                 attachments=attachments,
                 integration_id=str(integration.id)
             )
-            if response:
+            if attachments_response:
                 attachments_processed += len(attachments)
         except Exception as e:
             request = {
@@ -297,7 +298,8 @@ async def save_events_state(response, events, integration):
                 source_id=event_id
             )
         except Exception as e:
-            message = f"Error while saving event ID '{event.get('event_id')}'. Exception: {e}."
+            inat_id = event.get("event_details", {}).get("inat_id", "unknown")
+            message = f"Error while saving event ID '{inat_id}'. Exception: {e}."
             logger.exception(message, extra={
                 "integration_id": str(integration.id),
                 "attention_needed": True
@@ -305,28 +307,42 @@ async def save_events_state(response, events, integration):
             raise e
 
 
-def _match_annotations_to_config(annotations: List[Annotation], config: Dict[int, List[int]]):
+def _match_annotations_to_config(annotations: List[Annotation], config: Dict) -> bool:
+    """Check that the observation has all annotation term/value pairs required by config."""
     annot_map = {}
     for annotation in annotations:
-        if(annotation.term not in annot_map):
-            annot_map[annotation.term] = []
-        annot_map[annotation.term].append(annotation.value)
+        key = str(annotation.term)
+        if key not in annot_map:
+            annot_map[key] = []
+        annot_map[key].append(str(annotation.value))
 
-    for term, values in config:
-        if(str(term) not in annot_map):
+    for term, values in config.items():
+        term_str = str(term)
+        if term_str not in annot_map:
             return False
+        allowed = annot_map[term_str]
         for value in values:
-            if(str(value) not in annot_map[str(term)]):
+            if str(value) not in allowed:
                 return False
-    
     return True
+
+
+def _normalize_recorded_at(observed_on, created_at):
+    """Return a timezone-aware datetime for Gundi recorded_at (date or datetime, naive or aware)."""
+    if not observed_on:
+        return created_at
+    if isinstance(observed_on, date) and not isinstance(observed_on, datetime):
+        return datetime.combine(observed_on, datetime.min.time(), tzinfo=timezone.utc)
+    if getattr(observed_on, "tzinfo", None) is None:
+        return observed_on.replace(tzinfo=timezone.utc)
+    return observed_on
 
 
 def _transform_inat_to_gundi_event(ob: Observation, config: PullEventsConfig):
     
     event = {
         "event_type": config.event_type,
-        "recorded_at": ob.observed_on.replace(tzinfo=timezone.utc) if ob.observed_on else ob.created_at,
+        "recorded_at": _normalize_recorded_at(ob.observed_on, ob.created_at),
         "event_details": {
             "inat_id": str(ob.id),
             "captive": ob.captive,
@@ -349,8 +365,8 @@ def _transform_inat_to_gundi_event(ob: Observation, config: PullEventsConfig):
             "lat": ob.location[0],
             "lon": ob.location[1] }
 
-    if(ob.place_ids):
-        event["event_details"]["place_ids"] = ",".join([str(int) for int in ob.place_ids])
+    if ob.place_ids:
+        event["event_details"]["place_ids"] = ",".join(str(pid) for pid in ob.place_ids)
 
     if(ob.taxon):
         event["event_details"].update({
@@ -364,8 +380,8 @@ def _transform_inat_to_gundi_event(ob: Observation, config: PullEventsConfig):
 
         if(ob.taxon.preferred_common_name):
             event["title"] = ob.taxon.preferred_common_name
-        if(ob.taxon.ancestor_ids):
-            event["event_details"]["taxon_ancestors"] = ",".join([str(int) for int in ob.taxon.ancestor_ids])
+        if ob.taxon.ancestor_ids:
+            event["event_details"]["taxon_ancestors"] = ",".join(str(aid) for aid in ob.taxon.ancestor_ids)
 
     if(not event.get("title")):
         event["title"] = "Unknown" if not ob.species_guess else ob.species_guess

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,11 +1,10 @@
 from datetime import date, datetime, timedelta, timezone
 import logging
-from math import ceil
 from typing import Dict, List
 
-from gundi_core.schemas.v2 import Integration, LogLevel
 import httpx
-from pyinaturalist import Annotation, Observation, get_observations_v2
+from gundi_core.schemas.v2 import Integration, LogLevel
+from pyinaturalist import Observation
 
 from app.actions.configurations import PullEventsConfig
 from app.services.activity_logger import activity_logger, log_action_activity
@@ -14,12 +13,30 @@ from app.services.gundi import (
     send_events_to_gundi,
     update_event_in_gundi,
 )
+from app.datasource.inaturalist import get_observations
 from app.services.state import IntegrationStateManager
 
 GUNDI_SUBMISSION_CHUNK_SIZE = 100
 
+# Pull-events state: single key for the cursor (legacy "updated_to" still read for backward compatibility)
+STATE_LAST_RUN_KEY = "last_run"
+STATE_DATETIME_FMT = "%Y-%m-%d %H:%M:%S%z"
+
 logger = logging.getLogger(__name__)
 state_manager = IntegrationStateManager()
+
+
+def _get_load_since(state: dict, fallback_days: int) -> datetime:
+    """Return the datetime to use for updated_since. Uses stored cursor or now - fallback_days."""
+    raw = state.get(STATE_LAST_RUN_KEY) or state.get("updated_to")
+    if raw:
+        return datetime.strptime(raw, STATE_DATETIME_FMT)
+    return datetime.now(tz=timezone.utc) - timedelta(days=fallback_days)
+
+
+def _build_pull_events_state(last_updated: datetime) -> dict:
+    """Build the state dict to persist after a pull_events run."""
+    return {STATE_LAST_RUN_KEY: last_updated.strftime(STATE_DATETIME_FMT)}
 
 async def handle_transformed_data(transformed_data, integration_id, action_id):
     try:
@@ -41,70 +58,6 @@ async def handle_transformed_data(transformed_data, integration_id, action_id):
     else:
         return response
 
-def get_inaturalist_observations(integration: Integration, config: PullEventsConfig, since: datetime):
-
-    nelat = nelng = swlat = swlng = None
-    if(config.bounding_box):
-        nelat, nelng, swlat, swlng = config.bounding_box
-
-    target_taxa = []
-    for taxa in config.taxa:
-        target_taxa.append(str(taxa))
-    target_taxa = ",".join(target_taxa)
-
-    fields = ",".join(["observed_on", "created_at", "id", "captive", "obscured", "place_guess", "quality_grade", "species_guess", "updated_at", 
-                       "uri", "photos", "user", "location", "place_ids", "taxon", "photos.large_url", "photos.url", "taxon.id", "taxon.rank", "taxon.name",
-                       "taxon.preferred_common_name", "taxon.wikipedia_url", "taxon.conservation_status", "user.id", "user.name", "user.login",
-                       "annotations.controlled_attribute_id", "annotations.controlled_value_id"])
-    get_observations_params = { "page": 1,
-                                "per_page": 0,
-                                "updated_since": since,
-                                "project_id" : config.projects,
-                                "quality_grade" : config.quality_grade,
-                                "taxon_id" : target_taxa, 
-                                "order_by" : "updated_at", 
-                                "order" : "asc"}
-    if nelat and nelng and swlat and swlng:
-        get_observations_params["nelat"] = nelat
-        get_observations_params["nelng"] = nelng
-        get_observations_params["swlat"] = swlat
-        get_observations_params["swlng"] = swlng
-    inat_count_req = get_observations_v2(**get_observations_params)
-    inat_count = inat_count_req.get("total_results") or 0
-    pages = ceil(inat_count / 200) if inat_count else 0
-
-    observation_map = {}
-    for page in range(1,pages+1):
-        logger.debug(f"Loading page {page} of {pages} from iNaturalist")
-        get_observations_v2_params = {
-            "page" : page,
-            "per_page" : 200, 
-            "updated_since" : since, 
-            "project_id" : config.projects,
-            "quality_grade" : config.quality_grade, 
-            "taxon_id" : target_taxa,
-            "order_by" : 'updated_at', 
-            "order":"asc", 
-            "fields":fields
-        }
-        if nelat and nelng and swlat and swlng:
-            get_observations_v2_params["nelat"] = nelat
-            get_observations_v2_params["nelng"] = nelng
-            get_observations_v2_params["swlat"] = swlat
-            get_observations_v2_params["swlng"] = swlng
-        response = get_observations_v2(**get_observations_v2_params)
-        observations = Observation.from_json_list(response)
-
-        logger.info(f"Loaded {len(observations)} observations from iNaturalist before annotation filters.")
-        for o in observations:
-            if(config.annotations):
-                if(_match_annotations_to_config(o.annotations, config.annotations)):    
-                    observation_map[o.id] = o
-            else:
-                observation_map[o.id] = o
-
-    return observation_map
-
 def chunk_list(list_a, chunk_size):
   for i in range(0, len(list_a), chunk_size):
     yield list_a[i:i + chunk_size]
@@ -115,15 +68,17 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     logger.info(f"Executing 'pull_events' action with integration {integration} and action_config {action_config}...")
 
     state = await state_manager.get_state(integration.id, "pull_events")
+    load_since = _get_load_since(state, action_config.days_to_load)
 
-    last_run = state.get('updated_to') or state.get('last_run')
-    now = datetime.now(tz=timezone.utc)
-    if(last_run):
-        load_since = datetime.strptime(last_run, '%Y-%m-%d %H:%M:%S%z')
-    else:
-        load_since = now - timedelta(days=action_config.days_to_load)
-
-    observations = get_inaturalist_observations(integration, action_config, load_since)
+    # Todo: write an async version of get_observations that uses httpx.AsyncClient to fetch the observations.
+    observations = get_observations(
+        load_since,
+        bounding_box=action_config.bounding_box,
+        taxa=action_config.taxa,
+        projects=action_config.projects,
+        quality_grade=action_config.quality_grade,
+        annotations=action_config.annotations,
+    )
 
     if not observations:
         msg = f"No new iNaturalist observations to process for integration ID: {str(integration.id)}."
@@ -134,6 +89,11 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
             level=LogLevel.WARNING,
             title=msg,
             data={"message": msg}
+        )
+        # Advance cursor so next run doesn't re-query the same window (avoids repeated heavy requests)
+        now = datetime.now(tz=timezone.utc)
+        await state_manager.set_state(
+            str(integration.id), "pull_events", _build_pull_events_state(now)
         )
         return {'result': {'events_extracted': 0,
                            'events_updated': 0,
@@ -204,12 +164,11 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         response = await patch_events(events_to_patch, action_config, integration)
         updated_count += len(response)
 
-    # Taking the most recent 'updated_at' date from all the extracted obs from iNaturalist
     last_updated = max(ob.updated_at for ob in observations.values())
-
-    logger.info(f"Updating state through {last_updated}")
-    state = {"last_run": last_updated.strftime('%Y-%m-%d %H:%M:%S%z')}
-    await state_manager.set_state(str(integration.id), "pull_events", state)
+    logger.info("Updating state through %s", last_updated)
+    await state_manager.set_state(
+        str(integration.id), "pull_events", _build_pull_events_state(last_updated)
+    )
         
     return {'result': {'events_extracted': added_count,
                        'events_updated': updated_count,
@@ -305,26 +264,6 @@ async def save_events_state(response, events, integration):
                 "attention_needed": True
             })
             raise e
-
-
-def _match_annotations_to_config(annotations: List[Annotation], config: Dict) -> bool:
-    """Check that the observation has all annotation term/value pairs required by config."""
-    annot_map = {}
-    for annotation in annotations:
-        key = str(annotation.term)
-        if key not in annot_map:
-            annot_map[key] = []
-        annot_map[key].append(str(annotation.value))
-
-    for term, values in config.items():
-        term_str = str(term)
-        if term_str not in annot_map:
-            return False
-        allowed = annot_map[term_str]
-        for value in values:
-            if str(value) not in allowed:
-                return False
-    return True
 
 
 def _normalize_recorded_at(observed_on, created_at):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -5,9 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.conftest import async_return
 from app.actions.handlers import (
     STATE_DATETIME_FMT,
     STATE_LAST_RUN_KEY,
+    STATE_INAT_UPDATED_AT_KEY,
     _build_pull_events_state,
     _get_load_since,
     _normalize_recorded_at,
@@ -248,6 +250,60 @@ async def test_handle_transformed_data_success(mocker):
         action_id="pull_events",
     )
     assert result == ["id-1"]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_events_skips_patch_when_observation_already_in_sync(mocker):
+    """When state has inat_updated_at equal to observation.updated_at, we should not patch (avoids updating every run)."""
+    from uuid import UUID
+    from pyinaturalist import Observation
+
+    fixed_updated = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    ob = Observation.from_json({
+        "id": 999,
+        "observed_on": "2024-06-15",
+        "created_at": "2024-06-15T10:00:00+00:00",
+        "updated_at": fixed_updated,
+        "captive": False,
+        "obscured": False,
+        "quality_grade": "research",
+        "species_guess": "Bird",
+        "uri": "https://www.inaturalist.org/observations/999",
+        "photos": [],
+        "user": None,
+        "location": None,
+        "place_ids": [],
+        "taxon": None,
+        "annotations": [],
+    })
+    observations_map = {999: ob}
+
+    async def get_state_side_effect(integration_id, action_id, source_id="no-source"):
+        if source_id == "no-source":
+            return {STATE_LAST_RUN_KEY: "2024-06-01 00:00:00+0000"}
+        if source_id == "999":
+            return {
+                "object_id": "gundi-uuid-999",
+                STATE_INAT_UPDATED_AT_KEY: fixed_updated.strftime(STATE_DATETIME_FMT),
+            }
+        return {}
+
+    mock_state = AsyncMock()
+    mock_state.get_state.side_effect = get_state_side_effect
+    mocker.patch("app.actions.handlers.state_manager", mock_state)
+    mocker.patch("app.actions.handlers.get_observations", return_value=observations_map)
+    mocker.patch("app.services.activity_logger.publish_event", AsyncMock())
+    mock_patch_events = mocker.patch("app.actions.handlers.patch_events", new_callable=AsyncMock)
+
+    integration = MagicMock()
+    integration.id = UUID("f03ec73e-f3fe-41b6-8597-3eb89dde5ae1")
+    config = PullEventsConfig(days_to_load=3, event_prefix="iNat: ")
+
+    result = await action_pull_events(integration, config)
+
+    assert result["result"]["events_updated"] == 0
+    assert result["result"]["events_extracted"] == 0
+    mock_patch_events.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,0 +1,267 @@
+"""Unit tests for app.actions.handlers."""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.actions.handlers import (
+    STATE_DATETIME_FMT,
+    STATE_LAST_RUN_KEY,
+    _build_pull_events_state,
+    _get_load_since,
+    _normalize_recorded_at,
+    _transform_inat_to_gundi_event,
+    action_pull_events,
+    chunk_list,
+    handle_transformed_data,
+)
+from app.actions.configurations import PullEventsConfig
+
+
+# --- _get_load_since ---
+
+
+def test_get_load_since_empty_state_uses_fallback_days():
+    state = {}
+    result = _get_load_since(state, 5)
+    now = datetime.now(tz=timezone.utc)
+    expected_floor = now - timedelta(days=6)
+    expected_ceil = now - timedelta(days=4)
+    assert expected_floor <= result <= expected_ceil
+    assert result.tzinfo is not None
+
+
+def test_get_load_since_with_last_run_parses_and_returns():
+    state = {STATE_LAST_RUN_KEY: "2024-01-15 12:00:00+0000"}
+    result = _get_load_since(state, 5)
+    assert result == datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_get_load_since_prefers_last_run_over_updated_to():
+    state = {
+        STATE_LAST_RUN_KEY: "2024-02-01 00:00:00+0000",
+        "updated_to": "2024-01-01 00:00:00+0000",
+    }
+    result = _get_load_since(state, 5)
+    assert result == datetime(2024, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_get_load_since_uses_updated_to_when_last_run_missing():
+    state = {"updated_to": "2024-03-10 08:30:00+0000"}
+    result = _get_load_since(state, 3)
+    assert result == datetime(2024, 3, 10, 8, 30, 0, tzinfo=timezone.utc)
+
+
+# --- _build_pull_events_state ---
+
+
+def test_build_pull_events_state():
+    dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = _build_pull_events_state(dt)
+    assert result == {STATE_LAST_RUN_KEY: "2024-06-01 12:00:00+0000"}
+    # Round-trip
+    parsed = datetime.strptime(result[STATE_LAST_RUN_KEY], STATE_DATETIME_FMT)
+    assert parsed == dt
+
+
+# --- chunk_list ---
+
+
+def test_chunk_list_exact_multiple():
+    assert list(chunk_list([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
+
+
+def test_chunk_list_partial_final():
+    assert list(chunk_list([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+
+def test_chunk_list_empty():
+    assert list(chunk_list([], 10)) == []
+
+
+def test_chunk_list_single_chunk():
+    assert list(chunk_list([1, 2, 3], 10)) == [[1, 2, 3]]
+
+
+# --- _normalize_recorded_at ---
+
+
+def test_normalize_recorded_at_none_returns_created_at():
+    created = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert _normalize_recorded_at(None, created) is created
+
+
+def test_normalize_recorded_at_date_only():
+    d = date(2024, 5, 10)
+    created = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    result = _normalize_recorded_at(d, created)
+    assert result == datetime(2024, 5, 10, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_normalize_recorded_at_naive_datetime():
+    naive = datetime(2024, 5, 10, 14, 30, 0)
+    created = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    result = _normalize_recorded_at(naive, created)
+    assert result.tzinfo == timezone.utc
+    assert result.replace(tzinfo=None) == naive
+
+
+def test_normalize_recorded_at_aware_datetime_unchanged():
+    aware = datetime(2024, 5, 10, 14, 30, 0, tzinfo=timezone.utc)
+    created = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert _normalize_recorded_at(aware, created) is aware
+
+
+# --- _transform_inat_to_gundi_event ---
+
+
+def _make_observation(
+    id_=12345,
+    observed_on=None,
+    created_at=None,
+    user=None,
+    location=None,
+    place_ids=None,
+    taxon=None,
+    **kwargs,
+):
+    """Minimal Observation-like object for transformation tests."""
+    from pyinaturalist import Observation
+
+    created_at = created_at or datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    data = {
+        "id": id_,
+        "observed_on": observed_on or "2024-06-15",
+        "created_at": created_at,
+        "captive": kwargs.get("captive", False),
+        "obscured": kwargs.get("obscured", False),
+        "place_guess": kwargs.get("place_guess"),
+        "quality_grade": kwargs.get("quality_grade", "research"),
+        "species_guess": kwargs.get("species_guess", "Some species"),
+        "updated_at": kwargs.get("updated_at", created_at),
+        "uri": kwargs.get("uri", "https://www.inaturalist.org/observations/12345"),
+        "photos": kwargs.get("photos", []),
+        "user": user,
+        "location": location,
+        "place_ids": place_ids or [],
+        "taxon": taxon,
+        "annotations": kwargs.get("annotations", []),
+    }
+    return Observation.from_json(data)
+
+
+def test_transform_inat_to_gundi_event_minimal():
+    ob = _make_observation()
+    config = PullEventsConfig(
+        days_to_load=3,
+        event_type="inat_observation",
+        event_prefix="iNat: ",
+    )
+    event = _transform_inat_to_gundi_event(ob, config)
+    assert event["event_type"] == "inat_observation"
+    assert event["event_details"]["inat_id"] == "12345"
+    assert event["title"] == "iNat: Some species"
+    assert "recorded_at" in event
+    assert event["event_details"]["place_guess"] is None
+
+
+def test_transform_inat_to_gundi_event_with_user_location_taxon():
+    ob = _make_observation(
+        user={"id": 99, "name": "Jane", "login": "jane"},
+        location=[-27.7, 16.7],
+        place_ids=[1, 2, 3],
+        taxon={
+            "id": 120255,
+            "rank": "species",
+            "name": "Crassula muscosa",
+            "preferred_common_name": "lizard's-tail",
+            "wikipedia_url": "http://en.wikipedia.org/wiki/Crassula_muscosa",
+            "ancestor_ids": [1, 2, 3],
+        },
+    )
+    config = PullEventsConfig(days_to_load=3, event_prefix="iNat: ")
+    event = _transform_inat_to_gundi_event(ob, config)
+    assert event["event_details"]["user_id"] == 99
+    assert event["event_details"]["user_name"] == "Jane"
+    assert event["location"] == {"lat": -27.7, "lon": 16.7}
+    assert event["event_details"]["place_ids"] == "1,2,3"
+    assert event["event_details"]["taxon_id"] == 120255
+    assert event["event_details"]["taxon_name"] == "Crassula muscosa"
+    assert event["title"] == "iNat: lizard's-tail"
+    assert event["event_details"]["taxon_ancestors"] == "1,2,3"
+
+
+def test_transform_inat_to_gundi_event_title_fallback_to_species_guess():
+    ob = _make_observation(
+        species_guess="Unknown Bird",
+        taxon={"id": 1, "rank": "species", "name": "Spp", "preferred_common_name": None},
+    )
+    config = PullEventsConfig(days_to_load=3, event_prefix="")
+    event = _transform_inat_to_gundi_event(ob, config)
+    assert event["title"] == "Unknown Bird"
+
+
+# --- action_pull_events: no observations path (state still updated) ---
+
+
+@pytest.mark.asyncio
+async def test_action_pull_events_no_observations_updates_state(mocker):
+    from uuid import UUID
+
+    mock_state = AsyncMock()
+    mock_state.get_state.return_value = {}
+    mocker.patch("app.actions.handlers.state_manager", mock_state)
+    mocker.patch("app.actions.handlers.get_observations", return_value={})
+    mocker.patch("app.actions.handlers.log_action_activity", AsyncMock())
+    mocker.patch("app.services.activity_logger.publish_event", AsyncMock())
+
+    integration = MagicMock()
+    integration.id = UUID("f03ec73e-f3fe-41b6-8597-3eb89dde5ae1")
+    config = PullEventsConfig(days_to_load=3, event_prefix="iNat: ")
+
+    result = await action_pull_events(integration, config)
+
+    assert result["result"]["events_extracted"] == 0
+    assert result["result"]["events_updated"] == 0
+    mock_state.set_state.assert_called_once()
+    call_args = mock_state.set_state.call_args[0]
+    assert call_args[0] == str(integration.id)
+    assert call_args[1] == "pull_events"
+    state = call_args[2]
+    assert STATE_LAST_RUN_KEY in state
+    # Should be a recent timestamp
+    from datetime import datetime
+    parsed = datetime.strptime(state[STATE_LAST_RUN_KEY], STATE_DATETIME_FMT)
+    assert parsed.tzinfo is not None
+
+
+# --- handle_transformed_data ---
+
+
+@pytest.mark.asyncio
+async def test_handle_transformed_data_success(mocker):
+    mocker.patch("app.actions.handlers.send_events_to_gundi", AsyncMock(return_value=["id-1"]))
+    result = await handle_transformed_data(
+        transformed_data=[{"title": "Test"}],
+        integration_id="int-123",
+        action_id="pull_events",
+    )
+    assert result == ["id-1"]
+
+
+@pytest.mark.asyncio
+async def test_handle_transformed_data_http_error_returns_message(mocker):
+    import httpx
+    mocker.patch(
+        "app.actions.handlers.send_events_to_gundi",
+        AsyncMock(side_effect=httpx.HTTPError("Server error")),
+    )
+    result = await handle_transformed_data(
+        transformed_data=[],
+        integration_id="int-456",
+        action_id="pull_events",
+    )
+    assert len(result) == 1
+    assert "int-456" in result[0]
+    assert "Server error" in result[0]

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -20,7 +20,7 @@ async def test_execute_pull_observations_action(
     mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
     mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
     mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
-    mocker.patch("app.actions.handlers.get_observations_v2", mock_get_observations_v2)
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", mock_get_observations_v2)
 
     response = await execute_action(
         integration_id=str(inaturalist_integration_v2.id),
@@ -51,7 +51,7 @@ async def test_execute_pull_observations_action_without_bounding_box(
     mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
     mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
     mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
-    mocker.patch("app.actions.handlers.get_observations_v2", mock_get_observations_v2)
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", mock_get_observations_v2)
 
     response = await execute_action(
         integration_id=str(inaturalist_integration_v2_without_bounding_box.id),

--- a/app/datasource/__init__.py
+++ b/app/datasource/__init__.py
@@ -1,0 +1,1 @@
+"""Data source adapters for external APIs (e.g. iNaturalist)."""

--- a/app/datasource/inaturalist.py
+++ b/app/datasource/inaturalist.py
@@ -1,0 +1,111 @@
+"""iNaturalist API client for fetching observations."""
+
+import logging
+from datetime import datetime
+from math import ceil
+from typing import Dict, List, Optional
+
+from pyinaturalist import Annotation, Observation, get_observations_v2
+
+logger = logging.getLogger(__name__)
+
+OBSERVATION_FIELDS = [
+    "observed_on", "created_at", "id", "captive", "obscured", "place_guess",
+    "quality_grade", "species_guess", "updated_at", "uri", "photos", "user",
+    "location", "place_ids", "taxon",
+    "photos.large_url", "photos.url",
+    "taxon.id", "taxon.rank", "taxon.name", "taxon.preferred_common_name",
+    "taxon.wikipedia_url", "taxon.conservation_status",
+    "user.id", "user.name", "user.login",
+    "annotations.controlled_attribute_id", "annotations.controlled_value_id",
+]
+
+
+def _match_annotations_to_config(annotations: List[Annotation], config: Dict) -> bool:
+    """Check that the observation has all annotation term/value pairs required by config."""
+    annot_map = {}
+    for annotation in annotations:
+        key = str(annotation.term)
+        if key not in annot_map:
+            annot_map[key] = []
+        annot_map[key].append(str(annotation.value))
+
+    for term, values in config.items():
+        term_str = str(term)
+        if term_str not in annot_map:
+            return False
+        allowed = annot_map[term_str]
+        for value in values:
+            if str(value) not in allowed:
+                return False
+    return True
+
+
+def get_observations(
+    since: datetime,
+    *,
+    bounding_box: Optional[List[float]] = None,
+    taxa: Optional[List[str]] = None,
+    projects: Optional[List[str]] = None,
+    quality_grade: Optional[List[str]] = None,
+    annotations: Optional[Dict] = None,
+) -> Dict[int, Observation]:
+    """
+    Fetch observations from iNaturalist updated since the given datetime.
+
+    Returns a dict mapping observation id -> Observation for all observations
+    that match the filters (and annotation filter when annotations is set).
+    """
+    nelat = nelng = swlat = swlng = None
+    if bounding_box and len(bounding_box) >= 4:
+        nelat, nelng, swlat, swlng = bounding_box[:4]
+
+    target_taxa = ",".join(str(t) for t in (taxa or []))
+    fields = ",".join(OBSERVATION_FIELDS)
+
+    base_params = {
+        "updated_since": since,
+        "order_by": "updated_at",
+        "order": "asc",
+    }
+    if target_taxa:
+        base_params["taxon_id"] = target_taxa
+    if projects is not None:
+        base_params["project_id"] = projects
+    if quality_grade is not None:
+        base_params["quality_grade"] = quality_grade
+    if nelat is not None and nelng is not None and swlat is not None and swlng is not None:
+        base_params["nelat"] = nelat
+        base_params["nelng"] = nelng
+        base_params["swlat"] = swlat
+        base_params["swlng"] = swlng
+
+    count_params = {**base_params, "page": 1, "per_page": 0}
+    inat_count_req = get_observations_v2(**count_params)
+    inat_count = inat_count_req.get("total_results") or 0
+    pages = ceil(inat_count / 200) if inat_count else 0
+
+    observation_map = {}
+    for page in range(1, pages + 1):
+        logger.debug("Loading page %s of %s from iNaturalist", page, pages)
+        page_params = {
+            **base_params,
+            "page": page,
+            "per_page": 200,
+            "fields": fields,
+        }
+        response = get_observations_v2(**page_params)
+        observations = Observation.from_json_list(response)
+
+        logger.info(
+            "Loaded %s observations from iNaturalist before annotation filters.",
+            len(observations),
+        )
+        for o in observations:
+            if annotations:
+                if _match_annotations_to_config(o.annotations, annotations):
+                    observation_map[o.id] = o
+            else:
+                observation_map[o.id] = o
+
+    return observation_map

--- a/app/datasource/tests/test_inaturalist.py
+++ b/app/datasource/tests/test_inaturalist.py
@@ -1,0 +1,179 @@
+"""Unit tests for app.datasource.inaturalist."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.datasource.inaturalist import (
+    OBSERVATION_FIELDS,
+    get_observations,
+    _match_annotations_to_config,
+)
+
+
+# --- _match_annotations_to_config (via get_observations or direct if we expose it) ---
+# We test the filtering behavior via get_observations with mocked API + annotations param.
+
+
+def _annotation(term: int, value: int):
+    """Minimal annotation-like object with .term and .value."""
+    return MagicMock(term=term, value=value)
+
+
+def test_match_annotations_to_config_empty_annotations_empty_config():
+    assert _match_annotations_to_config([], {}) is True
+
+
+def test_match_annotations_to_config_empty_annotations_non_empty_config():
+    assert _match_annotations_to_config([], {"22": ["24"]}) is False
+
+
+def test_match_annotations_to_config_matching():
+    annotations = [
+        _annotation(22, 24),
+        _annotation(1, 2),
+    ]
+    config = {"22": [24], "1": [2]}
+    assert _match_annotations_to_config(annotations, config) is True
+
+
+def test_match_annotations_to_config_string_keys_and_values():
+    """Config from JSON has string keys/values; annotation term/value may be int."""
+    annotations = [_annotation(22, 24), _annotation(1, 2)]
+    config = {"22": ["24"], "1": ["2"]}
+    assert _match_annotations_to_config(annotations, config) is True
+
+
+def test_match_annotations_to_config_missing_term():
+    annotations = [_annotation(22, 24)]
+    config = {"22": [24], "1": [2]}
+    assert _match_annotations_to_config(annotations, config) is False
+
+
+def test_match_annotations_to_config_missing_value():
+    annotations = [_annotation(22, 24), _annotation(1, 99)]
+    config = {"22": [24], "1": [2]}
+    assert _match_annotations_to_config(annotations, config) is False
+
+
+# --- get_observations ---
+
+
+def test_get_observations_empty_result(mocker):
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", return_value={"total_results": 0, "results": []})
+    result = get_observations(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert result == {}
+
+
+def test_get_observations_one_page(mocker):
+    from pyinaturalist import Observation
+
+    obs_dict = {
+        "id": 100,
+        "observed_on": "2024-06-01",
+        "created_at": "2024-06-01T12:00:00+00:00",
+        "updated_at": "2024-06-01T12:00:00+00:00",
+        "captive": False,
+        "obscured": False,
+        "quality_grade": "research",
+        "species_guess": "Bird",
+        "uri": "https://www.inaturalist.org/observations/100",
+        "photos": [],
+        "user": None,
+        "location": None,
+        "place_ids": [],
+        "taxon": None,
+        "annotations": [],
+    }
+    mock_response = {"total_results": 1, "page": 1, "per_page": 200, "results": [obs_dict]}
+
+    def side_effect(**kwargs):
+        if kwargs.get("per_page") == 0:
+            return {"total_results": 1, "results": []}
+        return mock_response
+
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", side_effect=side_effect)
+    result = get_observations(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert len(result) == 1
+    assert 100 in result
+    assert isinstance(result[100], Observation)
+
+
+def test_get_observations_passes_bounding_box_and_filters(mocker):
+    call_params = []
+
+    def capture(**kwargs):
+        call_params.append(kwargs.copy())
+        if kwargs.get("per_page") == 0:
+            return {"total_results": 0, "results": []}
+        return {"total_results": 0, "results": []}
+
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", side_effect=capture)
+    get_observations(
+        datetime(2024, 1, 1, tzinfo=timezone.utc),
+        bounding_box=[10.0, 20.0, -10.0, -20.0],
+        taxa=["123", "456"],
+        projects=["p1"],
+        quality_grade=["research"],
+    )
+    assert len(call_params) >= 1
+    first = call_params[0]
+    assert first.get("nelat") == 10.0
+    assert first.get("nelng") == 20.0
+    assert first.get("swlat") == -10.0
+    assert first.get("swlng") == -20.0
+    assert first.get("taxon_id") == "123,456"
+    assert first.get("project_id") == ["p1"]
+    assert first.get("quality_grade") == ["research"]
+
+
+def test_get_observations_annotation_filter_includes_only_matching(mocker):
+    from pyinaturalist import Observation
+
+    obs_with_annot = {
+        "id": 1,
+        "observed_on": "2024-06-01",
+        "created_at": "2024-06-01T12:00:00+00:00",
+        "updated_at": "2024-06-01T12:00:00+00:00",
+        "captive": False,
+        "obscured": False,
+        "quality_grade": "research",
+        "species_guess": "Bird",
+        "uri": "https://www.inaturalist.org/observations/1",
+        "photos": [],
+        "user": None,
+        "location": None,
+        "place_ids": [],
+        "taxon": None,
+        "annotations": [
+            {"controlled_attribute_id": 22, "controlled_value_id": 24},
+        ],
+    }
+    obs_without_annot = {**obs_with_annot, "id": 2, "annotations": []}
+    mock_response = {
+        "total_results": 2,
+        "page": 1,
+        "per_page": 200,
+        "results": [obs_with_annot, obs_without_annot],
+    }
+
+    def side_effect(**kwargs):
+        if kwargs.get("per_page") == 0:
+            return {"total_results": 2, "results": []}
+        return mock_response
+
+    mocker.patch("app.datasource.inaturalist.get_observations_v2", side_effect=side_effect)
+    result = get_observations(
+        datetime(2024, 1, 1, tzinfo=timezone.utc),
+        annotations={"22": [24]},
+    )
+    # Only the observation with matching annotation (22=24) should be included
+    assert len(result) == 1
+    assert 1 in result
+
+
+def test_observation_fields_constant():
+    assert "id" in OBSERVATION_FIELDS
+    assert "observed_on" in OBSERVATION_FIELDS
+    assert "taxon.id" in OBSERVATION_FIELDS


### PR DESCRIPTION
This pull request refactors and improves the iNaturalist "pull_events" action handler, focusing on more robust state management, efficiency, and code maintainability. The main improvements include replacing the legacy observation fetching logic with a new, modular approach, enhancing per-observation state tracking to avoid unnecessary updates, and cleaning up and reorganizing the code for clarity and future extensibility.

**State management and synchronization improvements:**

* Introduced new state keys and helper functions (`STATE_LAST_RUN_KEY`, `STATE_INAT_UPDATED_AT_KEY`, `_get_load_since`, `_build_pull_events_state`) to track both the overall last run and per-observation synchronization time, ensuring only changed observations are patched and avoiding redundant updates. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L1-R42) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R95-R130) [[3]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L289-R340)
* Updated the logic to persist the most recent `updated_at` timestamp from observations after each run, advancing the cursor to minimize repeated heavy requests. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R95-R130) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R184-R190)

**Observation fetching and filtering:**

* Replaced the monolithic `get_inaturalist_observations` function with a call to the new `get_observations` function from `app.datasource.inaturalist`, simplifying parameters and allowing for future async support. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L43-L106) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L117-R83)
* Improved annotation matching and observation filtering logic to be more robust and maintainable. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L43-L106) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L289-R340)

**Per-observation state and patch logic:**

* Enhanced the patching logic to only update events in Gundi when the source iNaturalist observation has changed since the last sync, reducing unnecessary API calls and load.
* Added `save_patched_events_state` to persist updated per-observation state after patching, using the observation's `updated_at` timestamp. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R184-R190) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L289-R340)

**Code cleanup and normalization:**

* Refactored and normalized datetime handling for observation timestamps, ensuring all datetimes are timezone-aware and consistently formatted. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L1-R42) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L289-R340)
* Cleaned up list comprehensions and string joins for IDs and ancestor IDs for clarity and correctness. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L352-R364) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L367-R379)

**Bug fixes and minor improvements:**

* Fixed a bug in attachment processing by renaming the response variable to avoid overwriting and ensure correct counting.
* Improved error logging and exception handling when saving event state, including more informative messages and context.