### PR TITLE
feat: Jira Ticket ERCS-7146, change taxa field from array to comma-separated string with batching

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -32,8 +32,8 @@ class PullEventsConfig(PullActionConfiguration):
     projects: Optional[List[str]] = pydantic.Field(title = "Project IDs",
         description="List of project IDs to pull from iNaturalist.")
     
-    taxa: Optional[List[str]] = pydantic.Field(title = "Taxa IDs", 
-        description="List of iNaturalist taxa IDs for which to load observations.")
+    taxa: Optional[str] = pydantic.Field(title = "Taxa IDs",
+        description="Comma-separated list of iNaturalist taxa IDs for which to load observations (e.g. '12345, 67890').")
     
     quality_grade: Optional[List[str]] = pydantic.Field(title = "Quality Grade",
         description = "If present, only observations that have one of the entered quality grades will be included.  As of November, 2024, valid iNaturalist values are casual, needs_id and/or research.")
@@ -57,6 +57,12 @@ class PullEventsConfig(PullActionConfiguration):
             "include_photos",
         ],
     )
+
+    @pydantic.validator("taxa", pre=True, always=True)
+    def coerce_taxa_list_to_str(cls, v):
+        if isinstance(v, list):
+            return ",".join(str(t) for t in v if t)
+        return v
 
     # Temporary validator to cope with a limitation in Gundi Portal.
     @pydantic.validator("event_type", "event_prefix", always=True)

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -180,6 +180,21 @@ def inaturalist_integration_v2_without_bounding_box():
 
 
 @pytest.fixture
+def inaturalist_integration_v2_with_taxa_string():
+    return Integration(id = UUID('f03ec73e-f3fe-41b6-8597-3eb89dde5ae1'), name = 'Test iNaturalist', type = IntegrationType(id = UUID('7ea7b0a7-71fc-4577-936d-268dd45137f0'), name = 'iNaturalist', value = 'inaturalist', description = 'Default type for integrations with Inaturalist', actions = [IntegrationAction(id = UUID('6e17fd45-903a-4cb2-bd61-ee2db7abf31a'), type = 'pull', name = 'Pull Events', value = 'pull_events', description = 'Inaturalist Pull Events action', action_schema = {}, ui_schema = {})], webhook = None), base_url = '', enabled = True, owner = Organization(id = UUID('9d0ceb0f-648f-4ffa-91ea-f2973796ffa2'), name = 'Chicago Parks', description = ''), configurations = [IntegrationActionConfiguration(id = UUID('39e0a6db-c7cd-4ab1-a9d8-13416eee04ab'), integration = UUID('f03ec73e-f3fe-41b6-8597-3eb89dde5ae1'), action = IntegrationActionSummary(id = UUID('6e17fd45-903a-4cb2-bd61-ee2db7abf31a'), type = 'pull', name = 'Pull Events', value = 'pull_events'), data = {
+    'taxa': '1633134, 1314810, 1128559',
+    'projects': [],
+    'event_type': 'inat_observation',
+    'annotations': '',
+    'bounding_box': '',
+    'days_to_load': 5,
+    'event_prefix': 'iNat: ',
+    'quality_grade': [],
+    'include_photos': True
+})], webhook_configuration = None, default_route = ConnectionRoute(id = UUID('a3a1f096-43fe-4102-8742-bd4f2c539a4d'), name = 'Test iNaturalist - Default Route'), additional = {}, status = 'healthy', status_details = 'No issues detected')
+
+
+@pytest.fixture
 def mock_get_observations_v2(mocker, 
                              mock_get_observations_v2_first_response,
                              mock_get_observations_v2_page_response,

--- a/app/actions/tests/test_pull_events.py
+++ b/app/actions/tests/test_pull_events.py
@@ -1,5 +1,9 @@
+import datetime
 import pytest
+from unittest.mock import MagicMock, call
 from app.conftest import async_return
+from app.actions.configurations import PullEventsConfig
+from app.datasource.inaturalist import get_observations, TAXA_BATCH_SIZE
 from app.services.action_runner import execute_action
 
 
@@ -63,3 +67,71 @@ async def test_execute_pull_observations_action_without_bounding_box(
     assert response["result"].get("photos_attached") == 5
     assert mock_get_observations_v2.called
     assert mock_get_observations_v2.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_pull_observations_action_with_taxa_string(
+        mocker, mock_gundi_client_v2, mock_state_manager, inaturalist_integration_v2_with_taxa_string,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, mock_config_manager,
+        mock_get_observations_v2, mock_publish_event, mock_gundi_client_v2_class
+):
+    mock_config_manager.get_integration_details.return_value = async_return(inaturalist_integration_v2_with_taxa_string)
+    mock_config_manager.get_action_configuration.return_value = async_return(inaturalist_integration_v2_with_taxa_string.configurations[0])
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mock_state_manager.get_state.return_value = async_return({})
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+    mock_inat = mocker.patch("app.datasource.inaturalist.get_observations_v2", mock_get_observations_v2)
+
+    response = await execute_action(
+        integration_id=str(inaturalist_integration_v2_with_taxa_string.id),
+        action_id="pull_events"
+    )
+    assert "result" in response
+    assert mock_inat.called
+    # taxa string "1633134, 1314810, 1128559" is a single batch — count call + 1 page call
+    assert mock_inat.call_count == 2
+    count_call_kwargs = mock_inat.call_args_list[0][1]
+    assert count_call_kwargs["taxon_id"] == "1633134,1314810,1128559"
+
+
+def test_taxa_validator_coerces_list_to_string():
+    config = PullEventsConfig(taxa=["123", "456", "789"], days_to_load=3, event_prefix="iNat: ")
+    assert config.taxa == "123,456,789"
+
+
+def test_taxa_validator_passes_string_through():
+    config = PullEventsConfig(taxa="123, 456, 789", days_to_load=3, event_prefix="iNat: ")
+    assert config.taxa == "123, 456, 789"
+
+
+def test_taxa_validator_handles_empty_list():
+    config = PullEventsConfig(taxa=[], days_to_load=3, event_prefix="iNat: ")
+    assert config.taxa == ""
+
+
+def test_taxa_validator_handles_none():
+    config = PullEventsConfig(taxa=None, days_to_load=3, event_prefix="iNat: ")
+    assert config.taxa is None
+
+
+def test_get_observations_batches_taxa(mocker):
+    mock_inat = mocker.patch("app.datasource.inaturalist.get_observations_v2")
+    mock_inat.return_value = {"total_results": 0, "page": 1, "per_page": 0, "results": []}
+
+    taxa_ids = [str(i) for i in range(250)]
+    taxa_str = ",".join(taxa_ids)
+
+    get_observations(datetime.datetime.now(), taxa=taxa_str)
+
+    # 250 IDs → 3 batches (100, 100, 50) → 3 count calls (per_page=0), 0 page calls (total=0)
+    assert mock_inat.call_count == 3
+    taxon_id_args = [c[1]["taxon_id"] for c in mock_inat.call_args_list]
+    assert taxon_id_args[0] == ",".join(taxa_ids[:TAXA_BATCH_SIZE])
+    assert taxon_id_args[1] == ",".join(taxa_ids[TAXA_BATCH_SIZE:TAXA_BATCH_SIZE * 2])
+    assert taxon_id_args[2] == ",".join(taxa_ids[TAXA_BATCH_SIZE * 2:])

--- a/app/datasource/inaturalist.py
+++ b/app/datasource/inaturalist.py
@@ -41,11 +41,45 @@ def _match_annotations_to_config(annotations: List[Annotation], config: Dict) ->
     return True
 
 
+TAXA_BATCH_SIZE = 100
+INAT_PAGE_SIZE = 200
+
+
+def _get_observations_for_taxa_batch(
+    base_params: Dict,
+    taxa_batch: Optional[str],
+    annotations: Optional[Dict],
+    fields: str,
+) -> Dict[int, Observation]:
+    params = {**base_params}
+    if taxa_batch:
+        params["taxon_id"] = taxa_batch
+
+    count_params = {**params, "page": 1, "per_page": 0}
+    inat_count = (get_observations_v2(**count_params).get("total_results") or 0)
+    pages = ceil(inat_count / INAT_PAGE_SIZE) if inat_count else 0
+
+    observation_map = {}
+    for page in range(1, pages + 1):
+        logger.debug("Loading page %s of %s from iNaturalist", page, pages)
+        response = get_observations_v2(**{**params, "page": page, "per_page": INAT_PAGE_SIZE, "fields": fields})
+        observations = Observation.from_json_list(response)
+        logger.info("Loaded %s observations from iNaturalist before annotation filters.", len(observations))
+        for o in observations:
+            if annotations:
+                if _match_annotations_to_config(o.annotations, annotations):
+                    observation_map[o.id] = o
+            else:
+                observation_map[o.id] = o
+
+    return observation_map
+
+
 def get_observations(
     since: datetime,
     *,
     bounding_box: Optional[List[float]] = None,
-    taxa: Optional[List[str]] = None,
+    taxa: Optional[str] = None,
     projects: Optional[List[str]] = None,
     quality_grade: Optional[List[str]] = None,
     annotations: Optional[Dict] = None,
@@ -60,7 +94,6 @@ def get_observations(
     if bounding_box and len(bounding_box) >= 4:
         nelat, nelng, swlat, swlng = bounding_box[:4]
 
-    target_taxa = ",".join(str(t) for t in (taxa or []))
     fields = ",".join(OBSERVATION_FIELDS)
 
     base_params = {
@@ -68,8 +101,6 @@ def get_observations(
         "order_by": "updated_at",
         "order": "asc",
     }
-    if target_taxa:
-        base_params["taxon_id"] = target_taxa
     if projects is not None:
         base_params["project_id"] = projects
     if quality_grade is not None:
@@ -80,32 +111,18 @@ def get_observations(
         base_params["swlat"] = swlat
         base_params["swlng"] = swlng
 
-    count_params = {**base_params, "page": 1, "per_page": 0}
-    inat_count_req = get_observations_v2(**count_params)
-    inat_count = inat_count_req.get("total_results") or 0
-    pages = ceil(inat_count / 200) if inat_count else 0
+    if taxa:
+        taxa_ids = [t.strip() for t in taxa.split(",") if t.strip()]
+        batches = [
+            ",".join(taxa_ids[i:i + TAXA_BATCH_SIZE])
+            for i in range(0, len(taxa_ids), TAXA_BATCH_SIZE)
+        ]
+    else:
+        batches = [None]
 
     observation_map = {}
-    for page in range(1, pages + 1):
-        logger.debug("Loading page %s of %s from iNaturalist", page, pages)
-        page_params = {
-            **base_params,
-            "page": page,
-            "per_page": 200,
-            "fields": fields,
-        }
-        response = get_observations_v2(**page_params)
-        observations = Observation.from_json_list(response)
-
-        logger.info(
-            "Loaded %s observations from iNaturalist before annotation filters.",
-            len(observations),
-        )
-        for o in observations:
-            if annotations:
-                if _match_annotations_to_config(o.annotations, annotations):
-                    observation_map[o.id] = o
-            else:
-                observation_map[o.id] = o
+    for batch in batches:
+        batch_results = _get_observations_for_taxa_batch(base_params, batch, annotations, fields)
+        observation_map.update(batch_results)
 
     return observation_map

--- a/app/datasource/inaturalist.py
+++ b/app/datasource/inaturalist.py
@@ -111,8 +111,8 @@ def get_observations(
         base_params["swlat"] = swlat
         base_params["swlng"] = swlng
 
-    if taxa:
-        taxa_ids = [t.strip() for t in taxa.split(",") if t.strip()]
+    taxa_ids = [t.strip() for t in taxa.split(",") if t.strip()] if taxa else []
+    if taxa_ids:
         batches = [
             ",".join(taxa_ids[i:i + TAXA_BATCH_SIZE])
             for i in range(0, len(taxa_ids), TAXA_BATCH_SIZE)

--- a/app/datasource/tests/test_inaturalist.py
+++ b/app/datasource/tests/test_inaturalist.py
@@ -113,7 +113,7 @@ def test_get_observations_passes_bounding_box_and_filters(mocker):
     get_observations(
         datetime(2024, 1, 1, tzinfo=timezone.utc),
         bounding_box=[10.0, 20.0, -10.0, -20.0],
-        taxa=["123", "456"],
+        taxa="123, 456",
         projects=["p1"],
         quality_grade=["research"],
     )


### PR DESCRIPTION
## Summary
- Replaces `taxa: Optional[List[str]]` with `taxa: Optional[str]` (comma-separated) to improve portal UX — users get a single text input instead of an "Add Item" array widget
- Adds a `pre=True` Pydantic validator that coerces existing stored arrays (e.g. `["123", "456"]`) to strings at runtime, so production configs work without a data migration
- Adds batched iNaturalist API requests (100 taxa IDs per batch / `TAXA_BATCH_SIZE`) to avoid `414 URI Too Long` errors when large numbers of taxa are configured
- Adds `INAT_PAGE_SIZE = 200` constant to replace magic number

## Test plan
- [ ] All 8 tests in `test_pull_events.py` pass
- [ ] Validator coerces old list format to string
- [ ] Validator passes new string format through unchanged
- [ ] Batching test verifies 250 IDs split into 3 correct batches
- [ ] End-to-end test with taxa string config verifies correct `taxon_id` query param
- [ ] Verify portal JSON schema is updated to `{"type": ["string", "null"]}` for the `taxa` field in stage

## RISKS
⚠️ This update could cause all integrations to fail unless the integration action is updated in Production simultaneously.
⚠️ There is also a concern about high data volume if users add a large number of taxa IDs without applying sufficient additional filters. (e.g., millions of events with photos within 3 days of data, and the integration allows users to specify up to 7 days)